### PR TITLE
Add custom headers support and also nonrender

### DIFF
--- a/diffbot.py
+++ b/diffbot.py
@@ -57,9 +57,13 @@ class Client(object):
             req = urllib2.Request(url, data.encode(ENCODING), headers)
             return json.loads(urllib2.urlopen(req).read().decode(ENCODING))
 
-    def endpoint(self, name):
+    def endpoint(self, name, no_render=False):
         """Generate the URL endpoint for the given API."""
-        return '{0}/v{1}/{2}'.format(API_ROOT, self._version, name)
+        endpoint_url = '{0}/v{1}/{2}'.format(API_ROOT, self._version, name)
+        if no_render:
+            # Turn off js to speed up processing
+            endpoint_url += '?norender'
+        return endpoint_url
 
     def api(self, name, url, **kwargs):
         """Generic API method."""
@@ -83,7 +87,7 @@ class Client(object):
         url = self.endpoint(name)
         if text or html:
             content_type = html and 'text/html' or 'text/plain'
-            headers_cust['Content-Type'] = content_type
+            headers_cust = {'Content-Type': content_type}
             if headers:
                 headers_cust = headers.copy()
                 headers_cust['Content-Type'] = content_type
@@ -123,13 +127,11 @@ class Client(object):
         if isinstance(urls, list):
             urls = ' '.join(urls)
         url = self.endpoint('crawl')
-        process_url = self.endpoint(api)
-        params = {
-            'token': self._token,
-            'seeds': urls,
-            'name': name,
-            'apiUrl': process_url,
-        }
+        process_url = self.endpoint(api, no_render=kwargs.get('no_render', False))
+        params = {'token': self._token,
+                  'seeds': urls,
+                  'name': name,
+                  'apiUrl': process_url,}
 
         # Add any additional named parameters as accepted by Crawlbot
         params['maxToCrawl'] = 10

--- a/diffbot.py
+++ b/diffbot.py
@@ -1,4 +1,4 @@
-"""Diffbot API wrapper."""
+"""Diffbot API wrapper. Edited Lee H"""
 import argparse
 import json
 import os

--- a/diffbot.py
+++ b/diffbot.py
@@ -33,7 +33,10 @@ class Client(object):
     def _get(url, headers=None, params=None):
         """HTTP GET request."""
         try:
-            response = requests.get(url, headers=headers, params=params)
+            if headers:
+                response = requests.get(url, headers=headers, params=params)
+            else:
+                response = response.get(url, params=params)
             response.raise_for_status()
             # If JSON fails, return raw data
             # (e.g. when downloading CSV job logs).

--- a/diffbot.py
+++ b/diffbot.py
@@ -159,7 +159,7 @@ class Job(Client):
     def control(self, **kwargs):
         params = {'token': self._token, 'name': self._name}
         params.update(kwargs)
-        res = self._get(self._url, params)
+        res = self._get(self._url, params=params)
         job = next(j for j in res['jobs'] if j['name'] == self._name)
         return job
 


### PR DESCRIPTION
Implements

- Allow custom headers setting, which is useful for some sites you may wish to scrape
- Also when doing a crawl we may want the process url to have the `&norender` parameter to stop javascript rendering to speed up performance of the crawl, so here allow for that.